### PR TITLE
fixed verbose name of owner in calendar model

### DIFF
--- a/backend/events/models.py
+++ b/backend/events/models.py
@@ -29,7 +29,7 @@ class Calendar(models.Model):
     owner = models.ForeignKey(
         get_user_model(),
         on_delete=models.CASCADE,
-        verbose_name='Календарь',
+        verbose_name='Владелец',
         related_name='calendars',
     )
 


### PR DESCRIPTION
При написании тестов и тестировании verbose_name заметил ошибку в поле. Исправил.