### PR TITLE
Update refresh token lifetime

### DIFF
--- a/backend/calendar_project/settings.py
+++ b/backend/calendar_project/settings.py
@@ -137,7 +137,7 @@ REST_FRAMEWORK = {
 
 SIMPLE_JWT = {
     'ACCESS_TOKEN_LIFETIME': timedelta(days=7),
-    "REFRESH_TOKEN_LIFETIME": timedelta(days=21),
+    'REFRESH_TOKEN_LIFETIME': timedelta(days=21),
     'AUTH_HEADER_TYPES': ('Bearer',),
 }
 

--- a/backend/calendar_project/settings.py
+++ b/backend/calendar_project/settings.py
@@ -137,6 +137,7 @@ REST_FRAMEWORK = {
 
 SIMPLE_JWT = {
     'ACCESS_TOKEN_LIFETIME': timedelta(days=7),
+    "REFRESH_TOKEN_LIFETIME": timedelta(days=21),
     'AUTH_HEADER_TYPES': ('Bearer',),
 }
 


### PR DESCRIPTION
Срок жизни refresh-токена увеличен до 21 дня (по дефолту сутки)