### PR TITLE
Feature/events filter

### DIFF
--- a/backend/api/filters.py
+++ b/backend/api/filters.py
@@ -1,0 +1,24 @@
+from django_filters import FilterSet, filters
+
+from events.models import Event
+
+
+class EventFilter(FilterSet):
+    """
+    Фильтр кверисета событий по полю calendar.
+    Если параметр calendar не передан, то возвращается пустой кверисет.
+    """
+
+    calendar = filters.BaseInFilter(
+        field_name='calendar__id',
+        lookup_expr='in'
+    )
+
+    class Meta:
+        model = Event
+        fields = ('calendar',)
+
+    def filter_queryset(self, queryset):
+        if not self.request.GET.get('calendar'):
+            return Event.objects.none()
+        return super().filter_queryset(queryset)

--- a/backend/api/v1/serializers/events.py
+++ b/backend/api/v1/serializers/events.py
@@ -109,6 +109,13 @@ class WriteEventSerializer(serializers.ModelSerializer):
                      'null': 'Дата начала мероприятия не может быть null',
                      }
                  },
+            'datetime_finish':
+                {'required': True, 'error_messages':
+                    {'required': 'Дата завершения мероприятия отсутствует',
+                     'invalid': 'Неправильный формат даты и времени',
+                     'null': 'Дата начала мероприятия не может быть null',
+                     }
+                 },
             'calendar':
                 {'required': True, 'error_messages':
                     {'required': 'Не выбран календарь',
@@ -134,4 +141,15 @@ class WriteEventSerializer(serializers.ModelSerializer):
             raise ValidationError(
                 {'calendar': 'Можно использовать только свой календарь'}
             )
+
+        keys = ('all_day', 'datetime_start', 'datetime_finish')
+        all_day, start, finish = [validated_data.get(key) for key in keys]
+        if all_day:
+            validated_data['datetime_start'] = start.replace(
+                hour=0, minute=0
+            )
+            validated_data['datetime_finish'] = finish.replace(
+                hour=23, minute=59
+            )
+
         return super().create(validated_data)

--- a/backend/api/v1/serializers/events.py
+++ b/backend/api/v1/serializers/events.py
@@ -63,8 +63,9 @@ class ShortCalendarSerializer(serializers.ModelSerializer):
 
 
 class ReadEventSerializer(serializers.ModelSerializer):
-
     calendar = ShortCalendarSerializer(read_only=True)
+    datetime_start = serializers.DateTimeField(format='%Y-%m-%dT%H:%M')
+    datetime_finish = serializers.DateTimeField(format='%Y-%m-%dT%H:%M')
 
     class Meta:
         model = Event

--- a/backend/api/v1/serializers/events.py
+++ b/backend/api/v1/serializers/events.py
@@ -113,7 +113,7 @@ class WriteEventSerializer(serializers.ModelSerializer):
                 {'required': True, 'error_messages':
                     {'required': 'Дата завершения мероприятия отсутствует',
                      'invalid': 'Неправильный формат даты и времени',
-                     'null': 'Дата начала мероприятия не может быть null',
+                     'null': 'Дата завершения мероприятия не может быть null',
                      }
                  },
             'calendar':
@@ -149,7 +149,7 @@ class WriteEventSerializer(serializers.ModelSerializer):
                 hour=0, minute=0
             )
             validated_data['datetime_finish'] = finish.replace(
-                hour=23, minute=59
+                hour=23, minute=59, second=59,
             )
 
         return super().create(validated_data)

--- a/backend/api/v1/views/events.py
+++ b/backend/api/v1/views/events.py
@@ -142,14 +142,14 @@ class EventViewSet(RequiredGETQueryParamMixin, viewsets.ModelViewSet):
             try:
                 start = datetime.strptime(
                     self.request.query_params.get(
-                        'start_dt'), '%Y-%m-%dT%H:%M')
+                        'start_dt'), '%Y-%m-%d')
                 finish = datetime.strptime(
                     self.request.query_params.get(
-                        'finish_dt'), '%Y-%m-%dT%H:%M')
+                        'finish_dt'), '%Y-%m-%d')
             except ValueError:
                 raise ValidationError(
-                    'Invalid date format. '
-                    'Please provide dates in the format YYYY-MM-DDTHH:MM')
+                    'Неправильный формат даты. '
+                    'Пожалуйста, укажите дату в формате YYYY-MM-DD')
 
             if start >= finish:
                 raise ValidationError(

--- a/backend/api/v1/views/events.py
+++ b/backend/api/v1/views/events.py
@@ -75,13 +75,13 @@ class CalendarViewSet(viewsets.ModelViewSet):
             OpenApiParameter(
                 'start_dt',
                 datetime,
-                description='Дата начала фильтрации: 2023-01-01T00:00',
+                description='Дата начала фильтрации: 2023-01-01',
                 required=True,
             ),
             OpenApiParameter(
                 'finish_dt',
                 datetime,
-                description='Дата окончания фильтрации: 2023-12-31T00:00',
+                description='Дата окончания фильтрации: 2023-12-31',
                 required=True,),
             OpenApiParameter(
                 'calendar',

--- a/backend/api/v1/views/events.py
+++ b/backend/api/v1/views/events.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from django.db.models import Q
+from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import (
     OpenApiParameter,
     extend_schema,
@@ -9,6 +10,7 @@ from drf_spectacular.utils import (
 from rest_framework import viewsets
 from rest_framework.exceptions import ValidationError
 
+from api.filters import EventFilter
 from api.permissions import (
     EventsOwnerOrAdminOrReadOnly,
     IsAuthenticatedOrCalendarOwnerOrReadOnly,
@@ -68,19 +70,24 @@ class CalendarViewSet(viewsets.ModelViewSet):
                     'список мероприятий. Если пользователь не авторизован '
                     'то он получает мероприятия только из базового '
                     'календарь. Если авторизован то и все мероприятия '
-                    'календарей пользователя.',
+                    'календарей пользователя. Незначащие нули необязательны.',
         parameters=[
             OpenApiParameter(
                 'start_dt',
                 datetime,
-                description='Дата начала фильтрации: 2023-01-01T00:00:00',
+                description='Дата начала фильтрации: 2023-01-01T00:00',
                 required=True,
             ),
             OpenApiParameter(
                 'finish_dt',
                 datetime,
-                description='Дата окончания фильтрации: 2023-12-31T00:00:00',
-                required=True,)
+                description='Дата окончания фильтрации: 2023-12-31T00:00',
+                required=True,),
+            OpenApiParameter(
+                'calendar',
+                int,
+                description='Несколько значений могут быть разделены запятыми',
+            )
         ]
     ),
     create=extend_schema(
@@ -109,10 +116,10 @@ class CalendarViewSet(viewsets.ModelViewSet):
 )
 class EventViewSet(RequiredGETQueryParamMixin, viewsets.ModelViewSet):
     queryset = Event.objects.all()
-    lookup_field = 'id'
     permission_classes = (EventsOwnerOrAdminOrReadOnly,)
     pagination_class = None
     required_query_params = ['start_dt', 'finish_dt', ]
+    filter_backends = (DjangoFilterBackend,)
 
     def get_queryset(self):
         """
@@ -128,20 +135,26 @@ class EventViewSet(RequiredGETQueryParamMixin, viewsets.ModelViewSet):
         и календаря админа.
         """
         if self.action == 'list':
+            self.filterset_class = EventFilter
             qs = super().get_queryset()
 
             # Проверка на правильность передаваемого формата даты в запрос.
             try:
                 start = datetime.strptime(
                     self.request.query_params.get(
-                        'start_dt'), '%Y-%m-%dT%H:%M:%S')
+                        'start_dt'), '%Y-%m-%dT%H:%M')
                 finish = datetime.strptime(
                     self.request.query_params.get(
-                        'finish_dt'), '%Y-%m-%dT%H:%M:%S')
+                        'finish_dt'), '%Y-%m-%dT%H:%M')
             except ValueError:
                 raise ValidationError(
                     'Invalid date format. '
-                    'Please provide dates in the format YYYY-MM-DDTHH:MM:SS')
+                    'Please provide dates in the format YYYY-MM-DDTHH:MM')
+
+            if start >= finish:
+                raise ValidationError(
+                    'Начальная дата не может быть больше конечной'
+                )
 
             # Исключаются события, которые начались позже,
             # либо закончились раньше
@@ -155,7 +168,7 @@ class EventViewSet(RequiredGETQueryParamMixin, viewsets.ModelViewSet):
                         'admin', self.request.user.username])
             return qs.filter(calendar__owner__username='admin')
 
-        return Event.objects.filter(id=self.kwargs.get('id'))
+        return super().get_queryset()
 
     def get_serializer_class(self):
         """

--- a/backend/events/models.py
+++ b/backend/events/models.py
@@ -36,7 +36,7 @@ class Calendar(models.Model):
         'Код цвета в формате HEX',
         max_length=7,
         validators=[RegexValidator(
-            regex='^[#a-fA-F0-9]+$',
+            regex='^#([a-fA-F0-9]{3}|[a-fA-F0-9]{6})$',
             message='Недопустимые символы в коде цвета!'
         )]
     )

--- a/backend/events/tests/test_calendar_endpoints.py
+++ b/backend/events/tests/test_calendar_endpoints.py
@@ -88,7 +88,7 @@ class CalendarTest(BaseAPITestCase):
                     reverse('calendars-list'),
                     {
                         'name': 'test_calendar',
-                        'color': '#FFF00',
+                        'color': '#FFF000',
                     }
                 )
                 self.assertEqual(
@@ -121,7 +121,7 @@ class CalendarTest(BaseAPITestCase):
                     response = method(
                         reverse('calendars-detail', args=(calendar_id,)),
                         {'name': 'new_calendar_name',
-                         'color': '#FFF00'}
+                         'color': '#FFF000'}
                     )
                     self.assertEqual(
                         response.status_code, expected_code,

--- a/backend/events/tests/test_events_enpoints.py
+++ b/backend/events/tests/test_events_enpoints.py
@@ -34,8 +34,9 @@ class EventTest(BaseAPITestCase):
                 response = client.get(
                     reverse('events-list'),
                     data={
-                        'start_dt': '2023-01-01T00:00:00',
-                        'finish_dt': '2023-12-01T00:00:00'
+                        'start_dt': '2023-01-01T00:00',
+                        'finish_dt': '2023-12-01T00:00',
+                        'calendar': 1,
                     }
                 )
                 self.assertEqual(

--- a/backend/events/tests/test_events_enpoints.py
+++ b/backend/events/tests/test_events_enpoints.py
@@ -34,8 +34,8 @@ class EventTest(BaseAPITestCase):
                 response = client.get(
                     reverse('events-list'),
                     data={
-                        'start_dt': '2023-01-01T00:00',
-                        'finish_dt': '2023-12-01T00:00',
+                        'start_dt': '2023-01-01',
+                        'finish_dt': '2023-12-01',
                         'calendar': 1,
                     }
                 )


### PR DESCRIPTION
changelog:
- Добавлена фильтрация событий по календарю. В параметре calendar передаются id (можно несколько через запятую)
- Изменено регулярное выражение для проверки правильности hex-кода #123 
- Добавлена проверка при get-запросе на эндпойнт /events/. Начальная дата не может быть больше конечной.
- Добавлено условие при создании события: если событие помечено как "целый день", то datetime поля заполняются соответствующим временем
- Изменен формат datetime полей в ответе ReadEventsSeriaizer: секунды не возвращаются
- Исправлено #129
- Отредактированы тесты