### PR TITLE
fix/calendar filter

### DIFF
--- a/backend/api/v1/views/events.py
+++ b/backend/api/v1/views/events.py
@@ -85,7 +85,7 @@ class CalendarViewSet(viewsets.ModelViewSet):
                 required=True,),
             OpenApiParameter(
                 'calendar',
-                int,
+                str,
                 description='Несколько значений могут быть разделены запятыми',
             )
         ]


### PR DESCRIPTION
Исправил баг в документации. Теперь можно через запятую указывать несколько календарей для фильтрации.